### PR TITLE
Straight flush

### DIFF
--- a/lib/poker_hands.ex
+++ b/lib/poker_hands.ex
@@ -72,4 +72,11 @@ defmodule PokerHands do
   def straight?(["9", "J", "K", "Q", "T"]), do: true
   def straight?(["A", "J", "K", "Q", "T"]), do: true
   def straight?(_values), do: false
+
+  def straight_flush?(values, suites) do
+    case {straight?(values), flush?(suites)} do
+      {true, true} -> true
+      _ -> false
+    end
+  end
 end

--- a/lib/poker_hands.ex
+++ b/lib/poker_hands.ex
@@ -60,4 +60,16 @@ defmodule PokerHands do
   def flush?(["S", "S", "S", "S", "S"]), do: true
   def flush?(["H", "H", "H", "H", "H"]), do: true
   def flush?(_suites), do: false
+
+  def straight?(["2", "3", "4", "5", "A"]), do: true
+  def straight?(["2", "3", "4", "5", "6"]), do: true
+  def straight?(["3", "4", "5", "6", "7"]), do: true
+  def straight?(["4", "5", "6", "7", "8"]), do: true
+  def straight?(["5", "6", "7", "8", "9"]), do: true
+  def straight?(["6", "7", "8", "9", "T"]), do: true
+  def straight?(["7", "8", "9", "J", "T"]), do: true
+  def straight?(["8", "9", "J", "Q", "T"]), do: true
+  def straight?(["9", "J", "K", "Q", "T"]), do: true
+  def straight?(["A", "J", "K", "Q", "T"]), do: true
+  def straight?(_values), do: false
 end

--- a/lib/poker_hands.ex
+++ b/lib/poker_hands.ex
@@ -26,11 +26,11 @@ defmodule PokerHands do
 
     cond do
       royal_flush?(values, suites) -> 1
-      # straight_flush?(values, suites) -> 2
+      straight_flush?(values, suites) -> 2
       # four_of_a_kind?(values) -> 3
       # full_house?(values) -> 4
       flush?(suites) -> 5
-      # straight?(values) -> 6
+      straight?(values) -> 6
       # three_of_a_kind?(values) -> 7
       # two_pairs -> 8
       # one_pair -> 9

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -25,12 +25,23 @@ defmodule PokerHandsTest do
       assert PokerHands.ranking(["TD", "JC", "QC", "KC", "AC"]) != 1
     end
 
+    test "It ranks a Straight Flush as a 2" do
+      assert PokerHands.ranking(["2C", "3C", "4C", "5C", "6C"]) == 2
+      assert PokerHands.ranking(["2C", "3C", "4C", "5C", "AC"]) == 2
+      assert PokerHands.ranking(["9C", "TC", "JC", "QC", "KC"]) == 2
+    end
+
     test "It ranks a Normal Flush as a 5" do
       assert PokerHands.ranking(["2D", "4D", "QD", "KD", "AD"]) == 5
       assert PokerHands.ranking(["2H", "4H", "QH", "KH", "AH"]) == 5
       assert PokerHands.ranking(["2S", "4S", "QS", "KS", "AS"]) == 5
       assert PokerHands.ranking(["2C", "4C", "QC", "KC", "AC"]) == 5
       assert PokerHands.ranking(["2C", "4D", "QD", "KD", "AD"]) != 5
+    end
+
+    test "It ranks a Normal Straight as a 6" do
+      assert PokerHands.ranking(["2D", "3D", "4C", "5D", "AD"]) == 6
+      assert PokerHands.ranking(["2D", "3D", "4C", "5D", "6D"]) == 6
     end
   end
 

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -87,6 +87,19 @@ defmodule PokerHandsTest do
 
       assert PokerHands.straight?(["3", "4", "5", "A", "K"]) == false
       assert PokerHands.straight?(["3", "4", "5", "9", "T"]) == false
+
+      # Cannot loop the deck
+      assert PokerHands.straight?(["2", "3", "A", "K", "Q"]) == false
+    end
+  end
+
+  describe ".straight_flush?/2" do
+    test "It returns true if a hand is a Straight Flush" do
+      assert PokerHands.straight_flush?(["2", "3", "4", "5", "A"], ["C", "C", "C", "C", "C"]) == true
+      assert PokerHands.straight_flush?(["9", "J", "K", "Q", "T"], ["H", "H", "H", "H", "H"]) == true
+
+      assert PokerHands.straight_flush?(["2", "3", "4", "5", "A"], ["C", "S", "C", "C", "C"]) == false
+      assert PokerHands.straight_flush?(["9", "J", "K", "Q", "T"], ["H", "H", "H", "C", "H"]) == false
     end
   end
 end

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -71,4 +71,22 @@ defmodule PokerHandsTest do
       assert PokerHands.flush?(["D", "H", "C", "H", "S"]) == false
     end
   end
+
+  describe ".straight?/1" do
+    test "It returns true if a hand is a Straight" do
+      assert PokerHands.straight?(["2", "3", "4", "5", "A"]) == true
+      assert PokerHands.straight?(["2", "3", "4", "5", "6"]) == true
+      assert PokerHands.straight?(["3", "4", "5", "6", "7"]) == true
+      assert PokerHands.straight?(["4", "5", "6", "7", "8"]) == true
+      assert PokerHands.straight?(["5", "6", "7", "8", "9"]) == true
+      assert PokerHands.straight?(["6", "7", "8", "9", "T"]) == true
+      assert PokerHands.straight?(["7", "8", "9", "J", "T"]) == true
+      assert PokerHands.straight?(["8", "9", "J", "Q", "T"]) == true
+      assert PokerHands.straight?(["9", "J", "K", "Q", "T"]) == true
+      assert PokerHands.straight?(["A", "J", "K", "Q", "T"]) == true
+
+      assert PokerHands.straight?(["3", "4", "5", "A", "K"]) == false
+      assert PokerHands.straight?(["3", "4", "5", "9", "T"]) == false
+    end
+  end
 end


### PR DESCRIPTION
Adds functions 
- .straight?/1 - to check a hand for a Straight 
- .straight_flush?/2 - combines .straight?/1 and .flush?/1 to check a hand for a Straight Flush

Updates:
- .ranking/1 to rank straight flushes as a 2 and normal straights as a 6

Added issue #1 :
Currently, .winner/1 is not accounting for a tie in rankings where both players have straights but the winner should be the high card between the two