### PR TITLE
Adds .winner? check for straight flush ties, reuses .straight_high_ca…

### DIFF
--- a/lib/poker_hands.ex
+++ b/lib/poker_hands.ex
@@ -9,7 +9,7 @@ defmodule PokerHands do
     cond do
       p1_ranking < p2_ranking -> :p1
       p1_ranking > p2_ranking -> :p2
-      p1_ranking == 6 -> straight_high_card_winner?(p1_values, p2_values)
+      p1_ranking == 6 || p1_ranking == 2 -> straight_high_card_winner?(p1_values, p2_values)
     end
   end
 

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -12,6 +12,11 @@ defmodule PokerHandsTest do
       assert PokerHands.winner?("TH JC QC KC AC 9D TS JD QS KC") == :p1
       assert PokerHands.winner?("9D TS JD QS KC TH JC QC KC AC") == :p2
     end
+
+    test "Competing Straight Flushes winner goes to the high card" do
+      assert PokerHands.winner?("3H 4H 5H 6H 7H 9D TD JD QD KD") == :p2
+      assert PokerHands.winner?("9D TD JD QD KD AH 2H 3H 4H 5H ") == :p1
+    end
   end
 
   describe ".straight_high_card_winner?/2" do


### PR DESCRIPTION
…rd_winner function

Competing straight flushes are now treated the same way as competing regular straights where the player with the higher straight wins.