### PR TITLE
Three of a kind

### DIFF
--- a/lib/poker_hands.ex
+++ b/lib/poker_hands.ex
@@ -26,6 +26,7 @@ defmodule PokerHands do
       p1_ranking == 3 -> four_of_a_kind_tie_breaker(p1_values, p2_values)
       p1_ranking == 2 || p1_ranking == 6 -> straight_tie_breaker(p1_values, p2_values)
       p1_ranking == 4 -> full_house_tie_breaker(p1_values, p2_values)
+      p1_ranking == 7 -> three_of_a_kind_tie_breaker(p1_values, p2_values)
     end
   end
 
@@ -244,4 +245,71 @@ defmodule PokerHands do
   end
 
   def three_of_a_kind?(_values), do: false
+
+  # Both player sets of three in beginning of lists
+  def three_of_a_kind_tie_breaker([p1_value_1, p1_value_2, p1_value_3, p1_value_4, p1_value_5],
+    [p2_value_1, p2_value_2, p2_value_3, p2_value_4, p2_value_5])
+    when p1_value_1 == p1_value_2 and p1_value_1 == p1_value_3 and
+         p2_value_1 == p2_value_2 and p2_value_1 == p2_value_3 do
+
+    three_of_a_kind_tie_breaker_assessment(p1_value_1, [p1_value_4, p1_value_5], p2_value_1, [p2_value_4, p2_value_5])
+  end
+
+  # Both player sets of three at end of lists
+  def three_of_a_kind_tie_breaker([p1_value_1, p1_value_2, p1_value_3, p1_value_4, p1_value_5],
+    [p2_value_1, p2_value_2, p2_value_3, p2_value_4, p2_value_5])
+    when p1_value_3 == p1_value_4 and p1_value_3 == p1_value_5 and
+         p2_value_3 == p2_value_4 and p2_value_3 == p2_value_5 do
+
+    three_of_a_kind_tie_breaker_assessment(p1_value_5, [p1_value_1, p1_value_2], p2_value_5, [p2_value_1, p2_value_2])
+  end
+
+  # Player 1 set of three in beginning of list
+  # Player 2 set of three at end of list
+  def three_of_a_kind_tie_breaker([p1_value_1, p1_value_2, p1_value_3, p1_value_4, p1_value_5],
+    [p2_value_1, p2_value_2, p2_value_3, p2_value_4, p2_value_5])
+    when p1_value_1 == p1_value_2 and p1_value_1 == p1_value_3 and
+         p2_value_3 == p2_value_4 and p2_value_3 == p2_value_5 do
+
+    three_of_a_kind_tie_breaker_assessment(p1_value_1, [p1_value_4, p1_value_5], p2_value_5, [p2_value_1, p2_value_2])
+  end
+
+  # Player 1 set of three at end of list
+  # Player 2 set of three in beginning of list
+  def three_of_a_kind_tie_breaker([p1_value_1, p1_value_2, p1_value_3, p1_value_4, p1_value_5],
+    [p2_value_1, p2_value_2, p2_value_3, p2_value_4, p2_value_5])
+    when p1_value_3 == p1_value_4 and p1_value_3 == p1_value_5 and
+         p2_value_1 == p2_value_2 and p2_value_1 == p2_value_3 do
+
+    three_of_a_kind_tie_breaker_assessment(p1_value_5, [p1_value_1, p1_value_2], p2_value_1, [p2_value_4, p2_value_5])
+  end
+
+  def three_of_a_kind_tie_breaker_assessment(p1_set_of_three_value, p1_other_values,
+    p2_set_of_three_value, p2_other_values) do
+
+      cond do
+        @value_map[p1_set_of_three_value] > @value_map[p2_set_of_three_value] -> :p1
+        @value_map[p1_set_of_three_value] < @value_map[p2_set_of_three_value] -> :p2
+        true -> high_card_assessment(p1_other_values, p2_other_values)
+      end
+  end
+
+  def high_card_assessment(p1_values, p2_values) do
+    p1_converted_values = Enum.map(p1_values, fn x -> @value_map[x] end) |> Enum.sort |> Enum.reverse
+    p2_converted_values = Enum.map(p2_values, fn x -> @value_map[x] end) |> Enum.sort |> Enum.reverse
+
+    cond do
+      Enum.at(p1_converted_values, 0) > Enum.at(p2_converted_values, 0) -> :p1
+      Enum.at(p1_converted_values, 0) < Enum.at(p2_converted_values, 0) -> :p2
+      Enum.at(p1_converted_values, 1) > Enum.at(p2_converted_values, 1) -> :p1
+      Enum.at(p1_converted_values, 1) < Enum.at(p2_converted_values, 1) -> :p2
+      Enum.at(p1_converted_values, 2) > Enum.at(p2_converted_values, 2) -> :p1
+      Enum.at(p1_converted_values, 2) < Enum.at(p2_converted_values, 2) -> :p2
+      Enum.at(p1_converted_values, 3) > Enum.at(p2_converted_values, 3) -> :p1
+      Enum.at(p1_converted_values, 3) < Enum.at(p2_converted_values, 3) -> :p2
+      Enum.at(p1_converted_values, 4) > Enum.at(p2_converted_values, 4) -> :p1
+      Enum.at(p1_converted_values, 4) < Enum.at(p2_converted_values, 4) -> :p2
+      true -> :tie
+    end
+  end
 end

--- a/lib/poker_hands.ex
+++ b/lib/poker_hands.ex
@@ -48,7 +48,7 @@ defmodule PokerHands do
       full_house?(values) -> {4, values}
       flush?(suites) -> {5, values}
       straight?(values) -> {6, values}
-      # three_of_a_kind?(values) -> {7, values}
+      three_of_a_kind?(values) -> {7, values}
       # two_pairs -> {8, values}
       # one_pair -> {9, values}
       true -> {10, values} # high card
@@ -230,4 +230,18 @@ defmodule PokerHands do
       true -> :tie
     end
   end
+
+  # Because .values/1 sorts the values,
+  # the set of three must be in the beginning or end of list
+  def three_of_a_kind?([value_1, value_2, value_3, _value_4, _value_5])
+    when value_1 == value_2 and value_1 == value_3 do
+      true
+  end
+
+  def three_of_a_kind?([_value_1, _value_2, value_3, value_4, value_5])
+    when value_3 == value_4 and value_3 == value_5 do
+      true
+  end
+
+  def three_of_a_kind?(_values), do: false
 end

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -52,6 +52,10 @@ defmodule PokerHandsTest do
     test "Full House ties if identical set of 3 and pair" do
       assert PokerHands.winner?("AH AD AS 2H 2D AH AD AS 2H 2D") == :tie
     end
+
+    test "Three of a kind ranks 7 for hands with just a set of three" do
+      assert PokerHands.winner?("AH AD AS 2H 5D AH JD 4S 2H 2D") == :p1
+    end
   end
 
   describe ".straight_tie_breaker/2" do

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -56,6 +56,19 @@ defmodule PokerHandsTest do
     test "Three of a kind ranks 7 for hands with just a set of three" do
       assert PokerHands.winner?("AH AD AS 2H 5D AH JD 4S 2H 2D") == :p1
     end
+
+    test "Three of a kind ties go to more valuable set of 3" do
+      assert PokerHands.winner?("AH AD AS 2H 5D KH KD KS 5H 2D") == :p1
+    end
+
+    test "Three of a kind ties with same set of 3 go to high card between remaining two cards" do
+      assert PokerHands.winner?("AH AD AS KH QD AH AD AS 3H 2D") == :p1
+      assert PokerHands.winner?("AH AD AS KH QD AH AD AS KD 2D") == :p1
+    end
+
+    test "Three of a kind ties if identical set of three and high card values" do
+      assert PokerHands.winner?("AH AD AS KH QD AH AD AS KH QD") == :tie
+    end
   end
 
   describe ".straight_tie_breaker/2" do


### PR DESCRIPTION
Closes #5 

Adds three of a kind ranking and hand assessment

Includes edge cases for tiebreakers following these rules from adda52.com:

```
If More Than One Player Holds Three Of A Kind, Then The Higher Value Of The Cards Used To Make The Three Of A Kind Determines The Winner. If Two Or More Players Have The Same Three Of A Kind, Then A Fourth Card (And A Fifth If Necessary) Can Be Used As Kickers To Determine The Winner.
```

To deal with the kicker cards, I added a function `.high_card_assessment/2`
- Takes two lists as arguments which are the remaining kicker cards to be assessed.
- It converts them to their values and sorts them in reverse order.  This allows to compare the higher valued kickers in order.
- This function could be reused for high card hands and other kickers potentially but may need refactoring
- Since there is so much logic in this function, I would like to refactor and test it more thoroughly, added issue #13 to address this 