### PR TITLE
Two pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # PokerHands
 
-**TODO: Add description**
+Solution to Project Euler Problem #54 - Poker Hands
+- Task was to build an application to determine the winner between two poker hands
+- Given a text file `poker.txt` with 1000 hands, how many hands does Player 1 win
+https://projecteuler.net/problem=54
 
-## Installation
+Built with [Elixir](https://elixir-lang.org/)
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `poker_hands` to your list of dependencies in `mix.exs`:
+## Format
 
-```elixir
-def deps do
-  [
-    {:poker_hands, "~> 0.1.0"}
-  ]
-end
-```
+Input
+- string
+- Example: `8C TS KC 9H 4S 7D 2S 5D 3S AC`
+- First 5 cards are Player 1 cards
+- Last 5 cards are Player 2 cards
+- First character is the value of the card (2 - Two, T - Ten, K - King)
+- Second character denotes the suite (S - Spades, H - Hearts, C - Clubs, D - Diamonds)
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/poker_hands](https://hexdocs.pm/poker_hands).
+## Poker Hand Rankings Tiebreakers
 
+https://www.adda52.com/poker/poker-rules/cash-game-rules/tie-breaker-rules

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -69,6 +69,26 @@ defmodule PokerHandsTest do
     test "Three of a kind ties if identical set of three and high card values" do
       assert PokerHands.winner?("AH AD AS KH QD AH AD AS KH QD") == :tie
     end
+
+    test "Two Pairs ranks 8 for hands with two sets of pairs" do
+      assert PokerHands.winner?("AH AD KS KH 5D AH JD 4S 2H 2D") == :p1
+    end
+
+    test "Two Pair ties go to the player with most valuable pair" do
+      assert PokerHands.winner?("AH AD KS KH 5D 2H 2D 4S 4H TD") == :p1
+    end
+
+    test "Two Pair ties with same high pair go to player with most valuable 2nd pair" do
+      assert PokerHands.winner?("AH AD KS KH 5D AH AD 4S 4H TD") == :p1
+    end
+
+    test "Two Pair ties with same two pairs got to player with more valuable kicker" do
+      assert PokerHands.winner?("AH AD KS KH 5D AH AD KS KH QD") == :p2
+    end
+
+    test "Two Pair ties if identical hand values" do
+      assert PokerHands.winner?("AH AS KS KH 5D AH AD KS KH 5H") == :tie
+    end
   end
 
   describe ".straight_tie_breaker/2" do


### PR DESCRIPTION
Closes #6 

- Adds hand assessment for two sets of pairs

Tiebreaker rules: https://www.adda52.com/poker/poker-rules/cash-game-rules/tie-breaker-rules
The Highest Pair Is Used To Determine The Winner. If Two Or More Players Have The Same Highest Pair, Then The Highest Of The Second Pair Determines The Winner. If Both Players Hold Identical Two Pairs, The Fifth Card Is Used To Break The Tie.

- Updated README with information about the problem statement



