### PR TITLE
One pair

### DIFF
--- a/lib/poker_hands.ex
+++ b/lib/poker_hands.ex
@@ -28,6 +28,7 @@ defmodule PokerHands do
       p1_ranking == 4 -> full_house_tie_breaker(p1_values, p2_values)
       p1_ranking == 7 -> three_of_a_kind_tie_breaker(p1_values, p2_values)
       p1_ranking == 8 -> two_pairs_tie_breaker(p1_values, p2_values)
+      p1_ranking == 9 -> one_pair_tie_breaker(p1_values, p2_values)
     end
   end
 
@@ -371,6 +372,40 @@ defmodule PokerHands do
   end
 
   def one_pair?(_values), do: false
+
+  def one_pair_tie_breaker(p1_values, p2_values) do
+    {p1_pair_value, p1_kickers} = find_one_pair(p1_values)
+    {p2_pair_value, p2_kickers} = find_one_pair(p2_values)
+
+    cond do
+      @value_map[p1_pair_value] > @value_map[p2_pair_value] -> :p1
+      @value_map[p1_pair_value] < @value_map[p2_pair_value] -> :p2
+      true -> high_card_assessment(p1_kickers, p2_kickers)
+    end
+  end
+
+  def find_one_pair([paired_value_1, paired_value_2 | kickers])
+    when paired_value_1 == paired_value_2 do
+      {paired_value_1, kickers}
+  end
+
+  def find_one_pair([kicker_1, paired_value_1, paired_value_2, kicker_2, kicker_3])
+    when paired_value_1 == paired_value_2 do
+      kickers = [kicker_1, kicker_2, kicker_3]
+      {paired_value_1, kickers}
+  end
+
+  def find_one_pair([kicker_1, kicker_2, paired_value_1, paired_value_2, kicker_3])
+    when paired_value_1 == paired_value_2 do
+      kickers = [kicker_1, kicker_2, kicker_3]
+      {paired_value_1, kickers}
+  end
+
+  def find_one_pair([kicker_1, kicker_2, kicker_3, paired_value_1, paired_value_2])
+    when paired_value_1 == paired_value_2 do
+      kickers = [kicker_1, kicker_2, kicker_3]
+      {paired_value_1, kickers}
+  end
 
   def high_card_assessment(p1_values, p2_values) do
     p1_converted_values = Enum.map(p1_values, fn x -> @value_map[x] end) |> Enum.sort |> Enum.reverse

--- a/lib/poker_hands.ex
+++ b/lib/poker_hands.ex
@@ -52,7 +52,7 @@ defmodule PokerHands do
       straight?(values) -> {6, values}
       three_of_a_kind?(values) -> {7, values}
       two_pairs?(values) -> {8, values}
-      # one_pair -> {9, values}
+      one_pair?(values) -> {9, values}
       true -> {10, values} # high card
     end
   end
@@ -350,6 +350,27 @@ defmodule PokerHands do
       {[value_1, value_4], kicker}
   end
 
+  def one_pair?([value_1, value_2, _value_3, _value_4, _value_5])
+    when value_1 == value_2 do
+      true
+  end
+
+  def one_pair?([_value_1, value_2, value_3, _value_4, _value_5])
+    when value_2 == value_3 do
+      true
+  end
+
+  def one_pair?([_value_1, _value_2, value_3, value_4, _value_5])
+    when value_3 == value_4 do
+      true
+  end
+
+  def one_pair?([_value_1, _value_2, _value_3, value_4, value_5])
+    when value_4 == value_5 do
+      true
+  end
+
+  def one_pair?(_values), do: false
 
   def high_card_assessment(p1_values, p2_values) do
     p1_converted_values = Enum.map(p1_values, fn x -> @value_map[x] end) |> Enum.sort |> Enum.reverse

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -93,6 +93,20 @@ defmodule PokerHandsTest do
     test "One Pair ranks 9 for hands with just one pair of card values" do
       assert PokerHands.winner?("AH AD KS 5H 2D AH JD 4S 2H 5D") == :p1
     end
+
+    test "One Pair ties go to player with more valuable pair" do
+      assert PokerHands.winner?("AH AD KS 5H 2D JH JD 4S 2H 5D") == :p1
+    end
+
+    test "One Pair ties with same valued pair go to player with high card kicker" do
+      assert PokerHands.winner?("AH AD KS 5H 2D AH AD 4S 2H 5D") == :p1
+      assert PokerHands.winner?("AH AD KS QH 2D AH AD KS 2H 5D") == :p1
+      assert PokerHands.winner?("AH AD KS QH 2D AH AD KS QH 5D") == :p2
+    end
+
+    test "One pair ties if players have same hand" do
+      assert PokerHands.winner?("AH AD KS QH 2D AH AD KS QH 2D") == :tie
+    end
   end
 
   describe ".straight_tie_breaker/2" do

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -89,6 +89,10 @@ defmodule PokerHandsTest do
     test "Two Pair ties if identical hand values" do
       assert PokerHands.winner?("AH AS KS KH 5D AH AD KS KH 5H") == :tie
     end
+
+    test "One Pair ranks 9 for hands with just one pair of card values" do
+      assert PokerHands.winner?("AH AD KS 5H 2D AH JD 4S 2H 5D") == :p1
+    end
   end
 
   describe ".straight_tie_breaker/2" do


### PR DESCRIPTION
Closes #7 

Adds one pair hand assessment and tiebreakers

https://www.adda52.com/poker/poker-rules/cash-game-rules/tie-breaker-rules
If Two Or More Players Hold A Single Pair Then Highest Pair Wins. If The Pairs Are Of The Same Value, The Highest Kicker Card Determines The Winner. A Second And Even Third Kicker Can Be Used If Necessary.

- I was able to reuse the `.high_card_assessment/2` function for tiebreakers with kickers