### PR TITLE
Adds high card tie-breaker implementation and tests

### DIFF
--- a/lib/poker_hands.ex
+++ b/lib/poker_hands.ex
@@ -29,6 +29,7 @@ defmodule PokerHands do
       p1_ranking == 7 -> three_of_a_kind_tie_breaker(p1_values, p2_values)
       p1_ranking == 8 -> two_pairs_tie_breaker(p1_values, p2_values)
       p1_ranking == 9 -> one_pair_tie_breaker(p1_values, p2_values)
+      p1_ranking == 10 -> high_card_assessment(p1_values, p2_values)
     end
   end
 

--- a/test/poker_hands_test.exs
+++ b/test/poker_hands_test.exs
@@ -107,6 +107,22 @@ defmodule PokerHandsTest do
     test "One pair ties if players have same hand" do
       assert PokerHands.winner?("AH AD KS QH 2D AH AD KS QH 2D") == :tie
     end
+
+    test "If no other hand is determined, player with High Card wins" do
+      assert PokerHands.winner?("AH JD 6S 4H 2D KH JD 7S 4H 2D") == :p1
+    end
+
+    test "High Card tie breakers go to player with next highest card" do
+      assert PokerHands.winner?("AH JD 6S 4H 2D AH KD 7S 4H 2D") == :p2
+      assert PokerHands.winner?("AH KD 6S 4H 2D AH KD 7S 4H 2D") == :p2
+      assert PokerHands.winner?("AH KD QS 4H 2D AH KD 7S 4H 2D") == :p1
+      assert PokerHands.winner?("AH KD QS JH 2D AH KD 7S 4H 2D") == :p1
+      assert PokerHands.winner?("AH KD QS JH 2D AH KD QS JH 7D") == :p2
+    end
+
+    test "High Card if identical 5 cards, results in tie" do
+      assert PokerHands.winner?("AH KD QS JH 2D AH KD QS JH 2D") == :tie
+    end
   end
 
   describe ".straight_tie_breaker/2" do


### PR DESCRIPTION
Closes #17 

- `.high_card_assessment/2` was already implemented to go through the kickers on other hands and works effectively for determining the winner in a high card tie breaker

https://www.adda52.com/poker/poker-rules/cash-game-rules/tie-breaker-rules
When No Player Has Even A Pair, Then The Highest Card Wins. When Both Players Have Identical High Cards, The Next Highest Card Wins, And So On Until Five Cards Have Been Used. In The Unusual Circumstance That Two Players Hold The Identical Five Cards, The Pot Would Be Split.